### PR TITLE
Soporte de diseño para móvil y desktop

### DIFF
--- a/src/components/app-menu.tsx
+++ b/src/components/app-menu.tsx
@@ -51,9 +51,11 @@ interface AppSidebarProps {
 const ProfileMenu = ({
   user,
   onClose,
+  setActiveMenuItem,
 }: {
   user: ProfileType;
   onClose: () => void;
+  setActiveMenuItem: (item: string | null) => void;
 }) => {
   return (
     <div
@@ -78,7 +80,19 @@ const ProfileMenu = ({
           <X className="size-4" />
         </Button>
       </div>
-      <div className="p-4 pt-2">
+      <div className="p-4 pt-2 space-y-2">
+        <div className="sm:hidden">
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => {
+              setActiveMenuItem("profile");
+              onClose();
+            }}
+          >
+            Mi Perfil
+          </Button>
+        </div>
         <LogoutButton className="w-full" />
       </div>
     </div>
@@ -111,7 +125,9 @@ export const AppMenu = ({ user }: AppSidebarProps) => {
     <>
       <Dialog
         open={activeMenuItem === "profile"}
-        onOpenChange={() => setActiveMenuItem(null)}
+        onOpenChange={(open) => {
+          if (!open) setActiveMenuItem(null);
+        }}
       >
         <DialogContent>
           <DialogTitle>Personaliza tu perfil</DialogTitle>
@@ -120,7 +136,7 @@ export const AppMenu = ({ user }: AppSidebarProps) => {
       </Dialog>
 
       <div className="absolute z-50 bottom-0 left-0 w-full sm:left-4 sm:w-auto sm:translate-x-0 sm:rounded-2xl sm:m-4 m-0 rounded-none">
-        {activeMenuItem && (
+        {activeMenuItem && activeMenuItem !== "profile" && (
           <div
             className="bg-indigo-950/90 rounded-t-2xl rounded-b-none sm:rounded-2xl mb-1 text-white relative max-h-96 overflow-hidden"
             style={{ width: `${menuWidth}px` }}
@@ -175,6 +191,7 @@ export const AppMenu = ({ user }: AppSidebarProps) => {
                 <ProfileMenu
                   user={user}
                   onClose={() => setShowMobileProfile(false)}
+                  setActiveMenuItem={setActiveMenuItem}
                 />
               </div>
             )}
@@ -196,7 +213,10 @@ export const AppMenu = ({ user }: AppSidebarProps) => {
                   <Button
                     variant="outline"
                     className="w-full"
-                    onClick={() => setActiveMenuItem("profile")}
+                    onClick={() => {
+                      setActiveMenuItem("profile");
+                      setShowMobileProfile(false);
+                    }}
                   >
                     Perfil
                   </Button>


### PR DESCRIPTION
### Cambios:

- Se agregó el botón de perfil, en dispositivos móviles.
<table>
  <tr>
    <td align="center"><b>Antes</b></td>
    <td align="center"><b>Después</b></td>
    <td align="center"><b>Modal activo</b></td>
  </tr>
  <tr>
    <td><img width="300" alt="Xiaomi-12-cafescript condorcoders com" src="https://github.com/user-attachments/assets/9b5e2b97-6471-4b59-b9c7-a7842888515e" /></td>
    <td><img width="300" alt="Xiaomi-12-localhost" src="https://github.com/user-attachments/assets/72cb6b62-dd95-4b11-b5ed-7cce3083b258" /></td>
    <td><img width="300" alt="Xiaomi-12-localhost (1)" src="https://github.com/user-attachments/assets/964eb445-7cb8-45a0-b565-4494ee602d29" /></td>
  </tr>
</table>

- Se arregló un bug que hacía que apareciera una pestaña en el sidebar cuando se abría el modal del perfil.

<table>
  <tr>
    <td align="center"><b>Antes</b></td>
    <td align="center"><b>Después</b></td>
  </tr>
  <tr>
    <td><img width="600" alt="Captura de pantalla de 2025-11-16 14-57-49" src="https://github.com/user-attachments/assets/ee0c49ec-81ac-4abe-a820-63016074098a" /></td>
    <td><img width="600" alt="Captura de pantalla de 2025-11-16 14-58-24" src="https://github.com/user-attachments/assets/2e71c5b4-1f22-4662-a590-c6b99d2f9702" /></td>
  </tr>
</table>